### PR TITLE
Gemini-Integration, Favoriten-Paginierung & Themen-API

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,6 +71,7 @@ jobs:
           QUARKUS_DATASOURCE_PASSWORD: quarkus_test
           QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://localhost:5439/quarkus_test
           GEMINIE_ACCESS_TOKEN: ${{ secrets.GEMINIE_ACCESS_TOKEN}}
+          MASTODON_PRIVATE_ACCESS_TOKEN: ${{ secrets.MASTODON_PRIVATE_ACCESS_TOKEN}}
           GEMINI_MODEL: ${{ vars.GEMINI_MODEL }}
         run: |
           chmod +x mvnw

--- a/.github/workflows/manuel-push.yml
+++ b/.github/workflows/manuel-push.yml
@@ -80,6 +80,7 @@ jobs:
           QUARKUS_DATASOURCE_PASSWORD: quarkus_test
           QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://localhost:5439/quarkus_test
           GEMINIE_ACCESS_TOKEN: ${{ secrets.GEMINIE_ACCESS_TOKEN}}
+          MASTODON_PRIVATE_ACCESS_TOKEN: ${{ secrets.MASTODON_PRIVATE_ACCESS_TOKEN}}
           GEMINI_MODEL: ${{ vars.GEMINI_MODEL }}
         run: |
           chmod +x mvnw

--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -70,6 +70,7 @@ jobs:
           QUARKUS_DATASOURCE_PASSWORD: quarkus_test
           QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://localhost:5439/quarkus_test
           GEMINIE_ACCESS_TOKEN: ${{ secrets.GEMINIE_ACCESS_TOKEN}}
+          MASTODON_PRIVATE_ACCESS_TOKEN: ${{ secrets.MASTODON_PRIVATE_ACCESS_TOKEN}}
           GEMINI_MODEL: ${{ vars.GEMINI_MODEL }}
         run: |
           chmod +x mvnw

--- a/pom.xml
+++ b/pom.xml
@@ -70,10 +70,17 @@
             <version>2.1.0</version>
         </dependency>
 
+
         <dependency>
             <groupId>com.google.genai</groupId>
             <artifactId>google-genai</artifactId>
             <version>1.8.0</version>
+        </dependency>
+        <dependency>
+            <!-- jsoup HTML parser library @ https://jsoup.org/ -->
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.21.1</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/hexix/GreetingResource.java
+++ b/src/main/java/com/hexix/GreetingResource.java
@@ -1,21 +1,13 @@
 package com.hexix;
 
+import com.hexix.mastodon.resource.MastodonClient;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
-import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.Month;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.chrono.ChronoZonedDateTime;
-import java.util.List;
 
 @Path("/status")
 public class GreetingResource {

--- a/src/main/java/com/hexix/ai/ThemenResource.java
+++ b/src/main/java/com/hexix/ai/ThemenResource.java
@@ -5,7 +5,6 @@ import jakarta.transaction.Transactional;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
-import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;

--- a/src/main/java/com/hexix/mastodon/api/MastodonDtos.java
+++ b/src/main/java/com/hexix/mastodon/api/MastodonDtos.java
@@ -1,0 +1,224 @@
+package com.hexix.mastodon.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public class MastodonDtos {
+
+    // Record für das Senden eines neuen Status
+    public record StatusPayload(String status, String visibility, String language) {}
+
+    // Record, um die Antwort von /verify_credentials abzubilden
+    // Wir brauchen hier nur die ID.
+    public record MastodonAccount(String id, String username) {}
+
+    // Record, um einen einzelnen empfangenen Status abzubilden
+    // @JsonProperty wird verwendet, um JSON-Felder (snake_case) auf Java-Felder (camelCase) zu mappen.
+    public record MastodonStatus(
+            String id,
+            String url,
+            @JsonProperty("created_at") ZonedDateTime createdAt,// Jackson wandelt den String automatisch in ein Datum um
+            MastodonAccount account,
+            String content,
+            StatusVisibility visibility,
+            boolean sensitive,
+            @JsonProperty("spoiler_text") String spoilerText,
+            @JsonProperty("media_attachments") List<MediaAttachment> mediaAttachments,
+            Application application,
+            @JsonProperty("reblogs_count") Integer reblogsCount,
+            @JsonProperty("favourites_count") Integer favouritesCount,
+            @JsonProperty("replies_count") Integer repliesCount,
+            Boolean reblogged,
+            @JsonProperty("reblog") Optional<MastodonStatus> reblog,
+            String language,
+            String text,
+            PreviewCard card
+
+) {
+        public enum StatusVisibility{
+            PUBLIC("public"),
+            UNLISTED("unlisted"),
+            PRIVATE("private"),
+            DIRECT("direct");
+
+            private final String value;
+
+            StatusVisibility(String value) {
+                this.value = value;
+            }
+
+            @JsonValue
+            public String getValue() {
+                return value;
+            }
+        }
+
+        public record Application(
+                String name,
+                String website
+        ){}
+    }
+
+
+    /**
+     * Stellt eine Vorschaukarte dar, die ein Link, ein Foto oder ein Video sein kann.
+     *
+     * @param url Die URL des Inhalts.
+     * @param title Der Titel des Inhalts.
+     * @param description Eine Beschreibung des Inhalts.
+     * @param type Der Typ der Karte (z. B. "video", "photo", "link").
+     * @param author_name Der Name des Autors.
+     * @param author_url Die URL zum Profil des Autors.
+     * @param provider_name Der Name des Anbieters (z. B. "YouTube", "Flickr").
+     * @param provider_url Die URL des Anbieters.
+     * @param html Der HTML-Code zum Einbetten des Inhalts.
+     * @param width Die Breite des Inhalts in Pixel.
+     * @param height Die Höhe des Inhalts in Pixel.
+     * @param image Die URL zu einem Vorschaubild.
+     * @param embed_url Die URL zum direkten Einbetten des Inhalts.
+     * @param blurhash Ein Blurhash-String für das Bild.
+     * @param authors Eine Liste von Autoren (normalerweise für Links).
+     */
+    public record PreviewCard(
+            String url,
+            String title,
+            String description,
+            String type,
+            String author_name,
+            String author_url,
+            String provider_name,
+            String provider_url,
+            String html,
+            int width,
+            int height,
+            String image,
+            String embed_url,
+            String blurhash,
+            List<PreviewCardAuthor> authors
+    ) {
+
+        public record PreviewCardAuthor(String name, String url, Optional<MastodonAccount> account){}
+    }
+
+
+
+
+    public record MediaAttachment(
+            String id,
+            MediaType type, // <-- Geändert von String zu MediaType
+            String url,
+            @JsonProperty("preview_url") Optional<String> previewUrl,
+            @JsonProperty("remote_url") Optional<String> remoteUrl,
+            @JsonProperty("text_url") Optional<String> textUrl,
+            Optional<Meta> meta,
+            Optional<String> description,
+            Optional<String> blurhash
+    ) {
+
+        /**
+         * Definiert die verschiedenen Arten von Medienanhängen.
+         * Die Annotation @JsonValue wird von Jackson verwendet, um die
+         * kleingeschriebenen String-Werte aus dem JSON auf die Enum-Konstanten abzubilden.
+         */
+        public enum MediaType {
+            IMAGE("image"),
+            VIDEO("video"),
+            GIFV("gifv"),
+            AUDIO("audio"),
+            UNKNOWN("unknown"); // Fallback für unbekannte Typen
+
+            private final String value;
+
+            MediaType(String value) {
+                this.value = value;
+            }
+
+            @JsonValue
+            public String getValue() {
+                return value;
+            }
+        }
+
+        /**
+         * Metadaten, die verschiedene Details über das Medium enthalten.
+         * Die Felder sind als Optional deklariert, da sie je nach Medientyp variieren.
+         *
+         * @param length Die Dauer als formatierter String (z.B. "0:01:28.65").
+         * @param duration Die Dauer in Sekunden.
+         * @param fps Bilder pro Sekunde (für Videos).
+         * @param size Die Abmessungen als String (z.B. "1280x720").
+         * @param width Die Breite in Pixel.
+         * @param height Die Höhe in Pixel.
+         * @param aspect Das Seitenverhältnis.
+         * @param audioEncode Informationen zur Audiokodierung.
+         * @param audioBitrate Die Bitrate des Audios.
+         * @param audioChannels Die Audiokanäle (z.B. "stereo").
+         * @param original Metadaten der Originaldatei.
+         * @param small Metadaten der Vorschauversion.
+         * @param focus Der Fokuspunkt für Bildausschnitte.
+         */
+        public record Meta(
+                Optional<String> length,
+                Optional<Double> duration,
+                Optional<Integer> fps,
+                Optional<String> size,
+                Optional<Integer> width,
+                Optional<Integer> height,
+                Optional<Double> aspect,
+                @JsonProperty("audio_encode") Optional<String> audioEncode,
+                @JsonProperty("audio_bitrate") Optional<String> audioBitrate,
+                @JsonProperty("audio_channels") Optional<String> audioChannels,
+                Optional<Original> original,
+                Optional<Small> small,
+                Optional<Focus> focus
+        ) {}
+
+        /**
+         * Metadaten spezifisch für die Originaldatei.
+         *
+         * @param width Die Breite in Pixel.
+         * @param height Die Höhe in Pixel.
+         * @param frameRate Die Bildrate (kann ein String wie "100/3" sein).
+         * @param duration Die genaue Dauer in Sekunden.
+         * @param bitrate Die Bitrate in bps.
+         */
+        public record Original(
+                Optional<Integer> width,
+                Optional<Integer> height,
+                @JsonProperty("frame_rate") Optional<String> frameRate,
+                Optional<Double> duration,
+                Optional<Integer> bitrate
+        ) {}
+
+        /**
+         * Metadaten spezifisch für die kleine Vorschauversion.
+         *
+         * @param width Die Breite in Pixel.
+         * @param height Die Höhe in Pixel.
+         * @param size Die Abmessungen als String (z.B. "400x225").
+         * @param aspect Das Seitenverhältnis.
+         */
+        public record Small(
+                int width,
+                int height,
+                String size,
+                double aspect
+        ) {}
+
+        /**
+         * Der Fokuspunkt des Bildes, verwendet für zugeschnittene Vorschaubilder.
+         * Die Werte reichen von -1.0 bis 1.0.
+         *
+         * @param x Die horizontale Position des Fokuspunktes.
+         * @param y Die vertikale Position des Fokuspunktes.
+         */
+        public record Focus(
+                double x,
+                double y
+        ) {}
+    }
+}

--- a/src/main/java/com/hexix/mastodon/resource/FavouritesResource.java
+++ b/src/main/java/com/hexix/mastodon/resource/FavouritesResource.java
@@ -1,0 +1,87 @@
+package com.hexix.mastodon.resource;
+
+import com.hexix.mastodon.api.MastodonDtos;
+import com.hexix.mastodon.resource.client.FavouritesClient;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Link;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.logging.Logger;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@RequestScoped
+public class FavouritesResource {
+
+    final Logger LOG = Logger.getLogger(this.getClass());
+
+
+    @Inject
+    @RestClient
+    FavouritesClient favouritesClient;
+
+    @ConfigProperty(name = "mastodon.private.access.token")
+    String privateAccessToken;
+
+    public List<MastodonDtos.MastodonStatus> getAllFavourites() {
+        return getNewFavourites(null);
+    }
+
+    public List<MastodonDtos.MastodonStatus> getNewFavourites(String sinceId) {
+
+        List<MastodonDtos.MastodonStatus> results = new LinkedList<>();
+        String minId = null;
+        String maxId = null;
+        String oldMaxId = null;
+        do {
+            oldMaxId = maxId;
+
+            try (final Response response = favouritesClient.favourites2("Bearer " + privateAccessToken, maxId, minId, sinceId, "40")) {
+
+                final List<MastodonDtos.MastodonStatus> mastodonStatuses = response.readEntity(new GenericType<>() {
+                });
+
+                final Link next = response.getLink("next");
+                if(next != null) {
+                    final String queryParams = next.getUri().getQuery();
+
+                    maxId = parseLink(queryParams, "max_id");
+                }
+
+                results.addAll(0, mastodonStatuses);
+
+            } catch (Exception e) {
+                LOG.error("Beim anfragen der Favourite ist ein Fehler aufgetreten:", e);
+                throw new RuntimeException(e);
+            }
+
+        }while (!Objects.equals(maxId, oldMaxId));
+
+
+        return results;
+    }
+
+    /**
+     * Eine einfache Hilfsmethode, um einen Wert aus dem Link-Header zu parsen.
+     */
+    private String parseLink(String link, String paramName) {
+        if (link == null || !link.contains(paramName)) {
+            return null;
+        }
+        // Einfacher Regex, um z.B. min_id=569 zu finden
+        Pattern pattern = Pattern.compile(paramName + "=([^&>]+)");
+        Matcher matcher = pattern.matcher(link);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/hexix/mastodon/resource/MastodonClient.java
+++ b/src/main/java/com/hexix/mastodon/resource/MastodonClient.java
@@ -1,6 +1,7 @@
-package com.hexix;
+package com.hexix.mastodon.resource;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.hexix.mastodon.api.MastodonDtos;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HeaderParam;
@@ -10,7 +11,6 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 import java.time.ZonedDateTime;
@@ -23,7 +23,7 @@ public interface MastodonClient {
     @POST
     @Path("/statuses")
     @Produces(MediaType.APPLICATION_JSON)
-    MastodonStatus postStatus(@HeaderParam("Authorization") String accessToken, StatusPayload status);
+    MastodonDtos.MastodonStatus postStatus(@HeaderParam("Authorization") String accessToken, MastodonDtos.StatusPayload status);
 
     /**
      * Ruft die Account-Informationen ab, die mit dem Access Token verknüpft sind.
@@ -33,7 +33,7 @@ public interface MastodonClient {
      */
     @GET
     @Path("/accounts/verify_credentials")
-    MastodonAccount verifyCredentials(@HeaderParam("Authorization") String accessToken);
+    MastodonDtos.MastodonAccount verifyCredentials(@HeaderParam("Authorization") String accessToken);
 
     /**
      * Ruft eine Liste der Status-Updates für eine gegebene Account-ID ab.
@@ -44,7 +44,7 @@ public interface MastodonClient {
      */
     @GET
     @Path("/accounts/{id}/statuses")
-    List<MastodonStatus> getAccountStatuses(
+    List<MastodonDtos.MastodonStatus> getAccountStatuses(
             @HeaderParam("Authorization") String accessToken,
             @PathParam("id") String accountId,
             @QueryParam("limit") Integer limit
@@ -58,7 +58,7 @@ public interface MastodonClient {
      */
     @DELETE
     @Path("/statuses/{id}")
-    MastodonStatus deleteStatus(
+    MastodonDtos.MastodonStatus deleteStatus(
             @HeaderParam("Authorization") String accessToken,
             @PathParam("id") String statusId
     );
@@ -68,19 +68,5 @@ public interface MastodonClient {
 
 
 
-    // Record für das Senden eines neuen Status
-    record StatusPayload(String status, String visibility, String language) {}
 
-    // Record, um die Antwort von /verify_credentials abzubilden
-    // Wir brauchen hier nur die ID.
-    record MastodonAccount(String id, String username) {}
-
-    // Record, um einen einzelnen empfangenen Status abzubilden
-    // @JsonProperty wird verwendet, um JSON-Felder (snake_case) auf Java-Felder (camelCase) zu mappen.
-    record MastodonStatus(
-            String id,
-            @JsonProperty("created_at") ZonedDateTime createdAt,// Jackson wandelt den String automatisch in ein Datum um
-            String content,
-            MastodonAccount account
-    ) {}
 }

--- a/src/main/java/com/hexix/mastodon/resource/client/FavouritesClient.java
+++ b/src/main/java/com/hexix/mastodon/resource/client/FavouritesClient.java
@@ -1,0 +1,35 @@
+package com.hexix.mastodon.resource.client;
+
+import com.hexix.mastodon.api.MastodonDtos;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import java.util.List;
+
+@Path("/api/v1")
+@RegisterRestClient(baseUri = "https://mastodon.hexix.de")
+public interface FavouritesClient {
+
+    @GET
+    @Path("/favourites")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<MastodonDtos.MastodonStatus> favourites(@HeaderParam("Authorization") String accessToken);
+
+    @GET
+    @Path("/favourites")
+    @Produces(MediaType.APPLICATION_JSON)
+    Response favourites2(
+            @HeaderParam("Authorization") String accessToken,
+            @QueryParam("max_id") String maxId, // Für "next"
+            @QueryParam("min_id") String minId,  // Für "prev"
+            @QueryParam("since_id") String sinceId,
+            @QueryParam("limit") String limit
+    );
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,12 +6,14 @@ feed.url=https://www.tagesschau.de/infoservices/alle-meldungen-100~rss2.xml
 mastodon.api.url=https://mastodon.hexix.de
 # Dein Access Token (besser als Umgebungsvariable!)
 mastodon.access.token=${MASTODON_ACCESS_TOKEN:key}
+mastodon.private.access.token=${MASTODON_PRIVATE_ACCESS_TOKEN:key}
 
 gemini.access.token=${GEMINIE_ACCESS_TOKEN:key}
 gemini.model=${GEMINI_MODEL:gemini-2.0-flash}
 
 # Konfiguration für den REST Client
-com.hexix.MastodonClient/mp-rest/url=${mastodon.api.url}
+com.hexix.mastodon.resource.MastodonClient/mp-rest/url=${mastodon.api.url}
+#com.hexix.mastodon.resource.client.FavouritesClient/mp-rest/url=${mastodon.api.url}
 
 
 # --- NEU: Datenbank-Konfiguration ---

--- a/src/test/java/com/hexix/mastodon/JsoupTest.java
+++ b/src/test/java/com/hexix/mastodon/JsoupTest.java
@@ -1,0 +1,50 @@
+package com.hexix.mastodon;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.jboss.logging.Logger;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.StringJoiner;
+
+@QuarkusTest
+public class JsoupTest {
+
+    final Logger LOG = Logger.getLogger(this.getClass());
+    private final static String WIKIPEDIA_CSS_QUERY = "#mw-content-text .mw-parser-output > p:not(:has(> b)):not(:has(> span.geo.noexcerpt))";
+    private final static String TAGESSCHAU_CSS_QUERY ="#content article > *:not(div.meldungsfooter)";
+
+    @Test
+    public void jsoupWikipedia() throws IOException {
+        Document doc = Jsoup.connect("https://de.wikipedia.org/wiki/Europ%C3%A4ische_Union").get();
+        LOG.info(doc.title());
+        Elements article = doc.select(WIKIPEDIA_CSS_QUERY);
+
+        LOG.debug(article.text());
+
+        Assertions.assertTrue(article.text().contains("Parlament"));
+    }
+
+
+    @Test
+    public void jsoupTagesschau() throws IOException {
+        Document doc = Jsoup.connect("https://www.tagesschau.de/wissen/gesundheit/prostata-krebs-vorsorge-100.html").get();
+        LOG.info(doc.title());
+        Elements article = doc.select(TAGESSCHAU_CSS_QUERY);
+        StringJoiner sj = new StringJoiner("\n");
+
+        for (Element element : article) {
+            sj.add(element.text());
+        }
+
+
+        LOG.debug(sj);
+
+        Assertions.assertTrue(sj.toString().contains("Krebs"));
+    }
+}

--- a/src/test/java/com/hexix/mastodon/resource/client/FavouritesClientTest.java
+++ b/src/test/java/com/hexix/mastodon/resource/client/FavouritesClientTest.java
@@ -1,0 +1,44 @@
+package com.hexix.mastodon.resource.client;
+
+import com.hexix.mastodon.api.MastodonDtos;
+import com.hexix.mastodon.resource.FavouritesResource;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+class FavouritesClientTest {
+
+    @Inject
+    @RestClient
+    FavouritesClient favouritesClient;
+
+    @Inject
+    FavouritesResource favouritesResource;
+
+    @ConfigProperty(name ="mastodon.private.access.token")
+    String privateAccessToken;
+
+
+
+    @Test
+    public void favouritesClient(){
+        final List<MastodonDtos.MastodonStatus> favourites = favouritesClient.favourites("Bearer " + privateAccessToken);
+
+        System.out.println(favourites);
+    }
+
+    @Test
+    public void setFavouritesResource(){
+        final List<MastodonDtos.MastodonStatus> favourites = favouritesResource.getNewFavourites("566");
+
+        System.out.println(favourites);
+    }
+
+}


### PR DESCRIPTION

## Zusammenfassung

Dieses Pull Request (PR) führt drei bedeutende neue Features und Verbesserungen ein:

1.  **Integration der Google Gemini AI (Prototyping):** Eine umfangreiche Test-Suite wurde hinzugefügt, um die Fähigkeiten der Gemini-API für zukünftige Features wie Inhaltsempfehlungen und automatisierte Post-Erstellung zu erforschen.
2.  **Vollständige Paginierung für Mastodon-Favoriten:** Die Anwendung kann nun die gesamte Historie der favorisierten Toots eines Nutzers abrufen, anstatt nur die erste Seite.
3.  **Neue Themen-API (`/themen`):** Ein neuer REST-Endpunkt wurde implementiert, um Themen (Topics) zu verwalten, die für die Inhaltsgenerierung verwendet werden können.

---

## Detaillierte Änderungen

### 1. Integration von Google Gemini AI (Prototyping)

Als Vorbereitung für zukünftige intelligente Funktionen wurde in `GoogleAiTest.java` eine grundlegende Erkundung der Gemini-API durchgeführt.

**Kernfunktionen des Prototyps:**

*   **Text-Embeddings & Semantische Ähnlichkeit:**
    *   Fähigkeit implementiert, Textinhalte in numerische Vektoren (Embeddings) umzuwandeln (siehe `simpleEmbedding()` und `new001EmbeddingsTest()`).
    *   Die Hilfsfunktion `getCosineSimilarity` berechnet die semantische Ähnlichkeit zwischen Texten und bildet die Grundlage für ein Empfehlungssystem.

*   **Prototyp eines Empfehlungssystems:**
    *   Die Methode `createProfileVector` generiert einen "Benutzerprofil-Vektor" aus dem Durchschnitt der Vektoren favorisierter Inhalte.
    *   Der Test `simpleEmbedding()` demonstriert, wie dieses Profil genutzt werden kann, um neue Inhalte zu bewerten und die relevantesten zu empfehlen.

*   **Fortgeschrittene Textgenerierung:**
    *   Tests (`simpleQuestionTest`, `simpleQuestionOnlineTest`) zeigen, wie Inhalte basierend auf einem Prompt generiert werden.
    *   Es wurde erfolgreich die **garantierte JSON-Ausgabe** (`responseMimeType("application/json")`) getestet, was für eine stabile programmatische Weiterverarbeitung entscheidend ist.
    *   Durch die Integration des `GoogleSearch`-Tools kann das Modell auf aktuelle Informationen aus dem Internet zugreifen, um fundiertere Antworten zu liefern.

### 2. Paginierung für Mastodon-Favoriten

Die Logik zum Abrufen von Favoriten wurde überarbeitet, um die Cursor-basierte Paginierung der Mastodon-API vollständig zu unterstützen.

**Technische Umsetzung:**

*   **`FavouritesResource.java`:**
    *   Die Methode `getNewFavourites` wurde um eine `do-while`-Schleife erweitert. Diese ruft so lange weitere Seiten ab, bis die API keine neuen Ergebnisse mehr liefert.
    *   Die Logik liest den `Link`-Header aus der API-Antwort, um die URL für die nächste Ergebnisseite (`rel="next"`) zu extrahieren.
    *   Eine neue Hilfsmethode `parseLink` extrahiert den `max_id`-Parameter aus der URL für den Folgeaufruf.

*   **`FavouritesClient.java`:**
    *   Eine neue Client-Methode `favourites2` wurde hinzugefügt. Sie gibt das gesamte `jakarta.ws.rs.core.Response`-Objekt zurück, um den Zugriff auf die für die Paginierung entscheidenden HTTP-Header zu ermöglichen.

### 3. Neue Themen-API

Ein neuer REST-Endpunkt unter `/themen` wurde geschaffen, um Themen für die Content-Erstellung zu verwalten.

**Endpunkte:**

*   **`GET /themen`**
    *   Gibt eine Liste aller gespeicherten Themen zurück.
    *   Die Ergebnisse werden absteigend nach dem `lastPost`-Datum sortiert, sodass die zuletzt verwendeten Themen zuerst erscheinen. Themen ohne Datum werden am Ende einsortiert.

*   **`POST /themen` (Content-Type: `text/plain`)**
    *   Erstellt ein neues Thema basierend auf dem übergebenen Text im Request-Body.
    *   Gibt das neu erstellte `ThemenDTO` zurück.