### PR TITLE
feat(ai): Rate-Limiting für Gemini API implementieren und Aufrufe verbessern

### DIFF
--- a/src/main/java/com/hexix/InitialDataSetup.java
+++ b/src/main/java/com/hexix/InitialDataSetup.java
@@ -23,9 +23,9 @@ public class InitialDataSetup {
 
 
 
-        final List<Feed> myBlogFeeds = List.of(new Feed("https://forgejo.org/releases/rss.xml", "Forgejo Release\n\n", "Forgejo hat eine neue Version veröffentlicht: \n\n", false),
-                new Feed("https://www.tagesschau.de/infoservices/alle-meldungen-100~rss2.xml", "", "", false),
-                new Feed("https://rss.p.theconnman.com/_/postgres.atom?includeRegex=%5E(latest%7C(1%5B6-9%5D%7C%5B2-9%5D%5Cd%7C%5Cd%7B3%2C%7D)(%5C.%5Cd%2B)*)%24", "Postges Docker Hub Release\n\n", "Postgres wurde in einer neuen Version veröffentlicht.\n\n", false) );
+        final List<Feed> myBlogFeeds = List.of(new Feed("https://forgejo.org/releases/rss.xml", "Forgejo Release\n\n", "Forgejo hat eine neue Version veröffentlicht: \n\n", false, false),
+                new Feed("https://www.tagesschau.de/infoservices/alle-meldungen-100~rss2.xml", "", "", false, false),
+                new Feed("https://rss.p.theconnman.com/_/postgres.atom?includeRegex=%5E(latest%7C(1%5B6-9%5D%7C%5B2-9%5D%5Cd%7C%5Cd%7B3%2C%7D)(%5C.%5Cd%2B)*)%24", "Postges Docker Hub Release\n\n", "Postgres wurde in einer neuen Version veröffentlicht.\n\n", false, false) );
 
 
         for (Feed myBlogFeed : myBlogFeeds) {
@@ -36,7 +36,7 @@ public class InitialDataSetup {
                 feed.feedUrl = myBlogFeed.feedUrl;
                 feed.title = myBlogFeed.title;
                 feed.defaultText = myBlogFeed.defaultText;
-                feed.isActive = true;
+                feed.isActive = myBlogFeed.isActive();
                 feed.tryAi = myBlogFeed.tryAi;
                 feed.persist();
             } else {
@@ -121,5 +121,5 @@ public class InitialDataSetup {
 
     }
 
-    record Feed(String feedUrl, String title, String defaultText, boolean tryAi){}
+    record Feed(String feedUrl, String title, String defaultText, boolean tryAi, boolean isActive){}
 }

--- a/src/main/java/com/hexix/ai/GeminiRequestEntity.java
+++ b/src/main/java/com/hexix/ai/GeminiRequestEntity.java
@@ -1,0 +1,65 @@
+package com.hexix.ai;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+
+@Entity
+@Table(indexes = {
+        @Index(name = "idx_RequestEntity_uuid", columnList = "uuid", unique = true),
+        @Index(name = "idx_RequestEntity_model", columnList = "model"),
+        @Index(name = "idx_RequestEntity_timestamp", columnList = "timestamp")
+})
+public class GeminiRequestEntity extends PanacheEntity {
+
+    String uuid = UUID.randomUUID().toString();
+
+    String model;
+
+    LocalDateTime timestamp = LocalDateTime.now();
+
+    @Column(columnDefinition = "TEXT")
+    String text;
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(final String uuid) {
+        this.uuid = uuid;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public void setModel(final String model) {
+        this.model = model;
+    }
+
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    private void setTimestamp(final LocalDateTime timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(final String text) {
+        this.text = text;
+    }
+
+    public static long countLast10Minutes(String model){
+        return find("model = ?1 and timestamp > ?2", model, LocalDateTime.now().minusMinutes(10)).count();
+    }
+}

--- a/src/main/java/com/hexix/ai/GenerateTextFromTextInput.java
+++ b/src/main/java/com/hexix/ai/GenerateTextFromTextInput.java
@@ -1,10 +1,17 @@
 package com.hexix.ai;
 
 import com.google.genai.Client;
+import com.google.genai.types.GenerateContentConfig;
 import com.google.genai.types.GenerateContentResponse;
+import com.google.genai.types.HarmBlockThreshold;
+import com.google.genai.types.HarmCategory;
+import com.google.genai.types.SafetySetting;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
+
+import java.util.List;
 
 
 @ApplicationScoped
@@ -16,14 +23,28 @@ public class GenerateTextFromTextInput {
     @ConfigProperty(name = "gemini.access.token")
     String accessToken;
 
-    @ConfigProperty(name = "gemini.model")
-    String geminiModel;
 
-    public String getAiMessage(String initPost){
+
+
+    @Transactional
+    public String getAiMessage(String geminiModel, String initPost){
         try(Client client = Client.builder().apiKey(accessToken).build()) {
             final PromptEntity prompt = PromptEntity.findLatest();
+
+
+            final String sendPrompt = String.format("%s \n\n'%s'", prompt.prompt, initPost);
+
+            final GeminiRequestEntity geminiRequestEntity = new GeminiRequestEntity();
+            geminiRequestEntity.setModel(geminiModel);
+            geminiRequestEntity.setText(sendPrompt);
+            geminiRequestEntity.persist();
+
+            final List<SafetySetting> safetySettings = List.of(
+                    SafetySetting.builder().category(HarmCategory.Known.HARM_CATEGORY_HATE_SPEECH).threshold(HarmBlockThreshold.Known.BLOCK_MEDIUM_AND_ABOVE).build(),
+                    SafetySetting.builder().category(HarmCategory.Known.HARM_CATEGORY_DANGEROUS_CONTENT).threshold(HarmBlockThreshold.Known.BLOCK_MEDIUM_AND_ABOVE).build());
+
             GenerateContentResponse response =
-                    client.models.generateContent(geminiModel, String.format("%s \n\n'%s'",prompt.prompt, initPost), null);
+                    client.models.generateContent(geminiModel, sendPrompt, GenerateContentConfig.builder().safetySettings(safetySettings).maxOutputTokens(500).build());
             LOG.info("Input message:" + initPost);
             LOG.info("Generated message: " + response.text());
             return response.text();


### PR DESCRIPTION
**Titel:** `feat(ai): Rate-Limiting für Gemini API implementieren`

**Beschreibung:**

#### Was ist der Zweck dieses Pull Requests?

Dieser PR führt ein serverseitiges Rate-Limiting für Anfragen an die Google Gemini API ein. Das primäre Ziel ist es, die Anzahl der API-Aufrufe zu kontrollieren, um Kosten zu senken und zu verhindern, dass die von der API vorgegebenen Nutzungsquoten überschritten werden.

Zusätzlich werden die API-Aufrufe selbst durch die Konfiguration von Sicherheitseinstellungen und Ausgabelimits robuster gestaltet.

#### Welche Änderungen wurden vorgenommen?

1.  **Datenbankbasiertes Logging der API-Anfragen (`GeminiRequestEntity`)**
    *   Es wurde eine neue JPA-Entität `GeminiRequestEntity` eingeführt, die jede ausgehende Anfrage an die Gemini-API protokolliert.
    *   Gespeichert werden das verwendete Modell, der Zeitstempel und der vollständige Prompt-Text.
    *   Eine Methode `countLast10Minutes(model)` ermöglicht die Abfrage der Anfragen der letzten 10 Minuten.

2.  **Implementierung der Rate-Limit-Logik (`FeedToTootScheduler`)**
    *   Vor der Generierung eines KI-gestützten Toots prüft der Scheduler nun, wie viele Anfragen in den letzten 10 Minuten bereits erfolgt sind.
    *   Ist das konfigurierte Limit (aktuell: 3 Anfragen) überschritten, wird die KI-Generierung für den aktuellen Feed-Eintrag übersprungen (`continue`), und der Prozess wird mit dem nächsten Eintrag fortgesetzt. Das verhindert eine Blockade des Schedulers.

3.  **Verbesserung des Gemini-Service (`GenerateTextFromTextInput`)**
    *   Der Service wurde refaktorisiert, um das zu verwendende Modell als Parameter zu akzeptieren.
    *   Jeder API-Aufruf wird nun vor dem Senden in der neuen `GeminiRequestEntity`-Tabelle persistiert.
    *   Die API-Aufrufe werden jetzt mit expliziten Sicherheitseinstellungen (`SafetySettings` gegen Hassrede und gefährliche Inhalte) und einem `maxOutputTokens`-Limit (500) konfiguriert, um die Qualität und Sicherheit der Antworten zu erhöhen.

4.  **Kleinere Anpassungen**
    *   Das `Feed`-Record in `InitialDataSetup` wurde um ein `isActive`-Feld erweitert, um Feeds bei der Initialisierung als standardmäßig inaktiv markieren zu können.

#### Wie kann diese Änderung getestet werden?

1.  Starte die Anwendung.
2.  Stelle sicher, dass in `application.properties` ein `gemini.model` konfiguriert ist.
3.  Sorge dafür, dass ein Feed in der `MONITORED_FEED`-Tabelle auf `tryAi = true` und `isActive = true` gesetzt ist.
4.  Löse den `FeedToTootScheduler` manuell aus oder warte auf die Ausführung.
5.  Verarbeite mehr als 3 neue Feed-Einträge innerhalb von 10 Minuten.
6.  **Erwartetes Verhalten:**
    *   Die ersten 3 Einträge sollten erfolgreich KI-generierte Toots erzeugen. Die Logs sollten die generierten Nachrichten anzeigen.
    *   Ab dem 4. Eintrag sollte die KI-Verarbeitung übersprungen werden. In den Logs sollte keine Fehlermeldung, sondern lediglich die Fortsetzung der Schleife zu sehen sein.
    *   Überprüfe die `GEMINI_REQUEST_ENTITY`-Tabelle in der Datenbank. Sie sollte die Einträge für die ersten 3 erfolgreichen API-Aufrufe enthalten.