### PR TITLE
Potential fix for code scanning alert no. 78: Cross-site scripting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.hexix</groupId>
     <artifactId>feed2mastodon</artifactId>
-    <version>0.8.32</version>
+    <version>0.8.33</version>
 
     <properties>
         <compiler-plugin.version>3.15.0</compiler-plugin.version>

--- a/src/main/java/de/hexix/mail/MailOAuthResource.java
+++ b/src/main/java/de/hexix/mail/MailOAuthResource.java
@@ -98,7 +98,7 @@ public class MailOAuthResource {
         MailboxAccount account = mailboxAccountService.getMailboxAccountByEmail(email);
         if (account == null) {
             LOG.warning("Mailbox account not found for email: " + email + " during OAuth callback.");
-            return Response.status(Response.Status.NOT_FOUND).entity("Mailbox account not found for email: " + escapeForHtml(email)).build();
+            return Response.status(Response.Status.NOT_FOUND).entity("Mailbox account not found.").build();
         }
 
         // Find the right provider based on the account configuration
@@ -106,14 +106,14 @@ public class MailOAuthResource {
         if (provider == null) {
             LOG.severe("No suitable OAuthProvider found for account: " + email + " during OAuth callback.");
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                    .entity("No suitable OAuthProvider found for account: " + escapeForHtml(email)).build();
+                    .entity("No suitable OAuthProvider found for account.").build();
         }
 
         try {
             provider.processCallback(account, code);
             mailboxAccountService.updateMailboxAccount(account);
             LOG.info("OAuth2 token successfully received and stored for " + email);
-            return Response.ok("OAuth2 token successfully received and stored for " + escapeForHtml(email)).build();
+            return Response.ok("OAuth2 token successfully received and stored.").build();
         } catch (Exception e) {
             LOG.severe("Error during OAuth callback for " + email + ": " + e.getMessage());
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Error processing callback: " + escapeForHtml(e.getMessage())).build();

--- a/src/main/java/de/hexix/mail/MailOAuthResource.java
+++ b/src/main/java/de/hexix/mail/MailOAuthResource.java
@@ -24,6 +24,18 @@ public class MailOAuthResource {
         return input.replace('\n', ' ').replace('\r', ' ');
     }
 
+    private static String escapeForHtml(String input) {
+        if (input == null) {
+            return null;
+        }
+        return input
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#x27;");
+    }
+
     @Inject
     MailboxAccountService mailboxAccountService;
 
@@ -75,7 +87,7 @@ public class MailOAuthResource {
         if (error != null) {
             LOG.warning("OAuth callback received an error: " + sanitizeForLog(error) + " - " + sanitizeForLog(errorDescription));
             return Response.status(Response.Status.BAD_REQUEST)
-                    .entity("OAuth error: " + error + (errorDescription != null ? " (" + errorDescription + ")" : "")).build();
+                    .entity("OAuth error: " + escapeForHtml(error) + (errorDescription != null ? " (" + escapeForHtml(errorDescription) + ")" : "")).build();
         }
 
         if (code == null || email == null) {
@@ -86,7 +98,7 @@ public class MailOAuthResource {
         MailboxAccount account = mailboxAccountService.getMailboxAccountByEmail(email);
         if (account == null) {
             LOG.warning("Mailbox account not found for email: " + email + " during OAuth callback.");
-            return Response.status(Response.Status.NOT_FOUND).entity("Mailbox account not found for email: " + email).build();
+            return Response.status(Response.Status.NOT_FOUND).entity("Mailbox account not found for email: " + escapeForHtml(email)).build();
         }
 
         // Find the right provider based on the account configuration
@@ -94,17 +106,17 @@ public class MailOAuthResource {
         if (provider == null) {
             LOG.severe("No suitable OAuthProvider found for account: " + email + " during OAuth callback.");
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                    .entity("No suitable OAuthProvider found for account: " + email).build();
+                    .entity("No suitable OAuthProvider found for account: " + escapeForHtml(email)).build();
         }
 
         try {
             provider.processCallback(account, code);
             mailboxAccountService.updateMailboxAccount(account);
             LOG.info("OAuth2 token successfully received and stored for " + email);
-            return Response.ok("OAuth2 token successfully received and stored for " + email).build();
+            return Response.ok("OAuth2 token successfully received and stored for " + escapeForHtml(email)).build();
         } catch (Exception e) {
             LOG.severe("Error during OAuth callback for " + email + ": " + e.getMessage());
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Error processing callback: " + e.getMessage()).build();
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Error processing callback: " + escapeForHtml(e.getMessage())).build();
         }
     }
 }

--- a/src/main/java/de/hexix/mail/MailOAuthResource.java
+++ b/src/main/java/de/hexix/mail/MailOAuthResource.java
@@ -81,30 +81,35 @@ public class MailOAuthResource {
     @Transactional
     public Response callback(@QueryParam("code") String code, @QueryParam("state") String email,
                              @QueryParam("error") String error, @QueryParam("error_description") String errorDescription) {
-        LOG.info("Received OAuth callback. Code: " + code + ", State (email): " + email +
-                 ", Error: " + sanitizeForLog(error) + ", Error Description: " + sanitizeForLog(errorDescription));
+        String safeCode = sanitizeForLog(code);
+        String safeEmail = sanitizeForLog(email);
+        String safeError = sanitizeForLog(error);
+        String safeErrorDescription = sanitizeForLog(errorDescription);
+
+        LOG.info("Received OAuth callback. Code: " + safeCode + ", State (email): " + safeEmail +
+                 ", Error: " + safeError + ", Error Description: " + safeErrorDescription);
 
         if (error != null) {
-            LOG.warning("OAuth callback received an error: " + sanitizeForLog(error) + " - " + sanitizeForLog(errorDescription));
+            LOG.warning("OAuth callback received an error: " + safeError + " - " + safeErrorDescription);
             return Response.status(Response.Status.BAD_REQUEST)
                     .entity("OAuth error: " + escapeForHtml(error) + (errorDescription != null ? " (" + escapeForHtml(errorDescription) + ")" : "")).build();
         }
 
         if (code == null || email == null) {
-            LOG.warning("Authorization code or state is missing in callback. Code: " + code + ", State: " + email);
+            LOG.warning("Authorization code or state is missing in callback. Code: " + safeCode + ", State: " + safeEmail);
             return Response.status(Response.Status.BAD_REQUEST).entity("Authorization code or state is missing.").build();
         }
 
         MailboxAccount account = mailboxAccountService.getMailboxAccountByEmail(email);
         if (account == null) {
-            LOG.warning("Mailbox account not found for email: " + email + " during OAuth callback.");
+            LOG.warning("Mailbox account not found for email: " + safeEmail + " during OAuth callback.");
             return Response.status(Response.Status.NOT_FOUND).entity("Mailbox account not found.").build();
         }
 
         // Find the right provider based on the account configuration
         OAuthProvider provider = oauthTokenService.getProviderForAccount(account);
         if (provider == null) {
-            LOG.severe("No suitable OAuthProvider found for account: " + email + " during OAuth callback.");
+            LOG.severe("No suitable OAuthProvider found for account: " + safeEmail + " during OAuth callback.");
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
                     .entity("No suitable OAuthProvider found for account.").build();
         }
@@ -112,10 +117,10 @@ public class MailOAuthResource {
         try {
             provider.processCallback(account, code);
             mailboxAccountService.updateMailboxAccount(account);
-            LOG.info("OAuth2 token successfully received and stored for " + email);
+            LOG.info("OAuth2 token successfully received and stored for " + safeEmail);
             return Response.ok("OAuth2 token successfully received and stored.").build();
         } catch (Exception e) {
-            LOG.log(java.util.logging.Level.SEVERE, "Error during OAuth callback for " + email, e);
+            LOG.log(java.util.logging.Level.SEVERE, "Error during OAuth callback for " + safeEmail, e);
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Error processing callback.").build();
         }
     }

--- a/src/main/java/de/hexix/mail/MailOAuthResource.java
+++ b/src/main/java/de/hexix/mail/MailOAuthResource.java
@@ -115,8 +115,8 @@ public class MailOAuthResource {
             LOG.info("OAuth2 token successfully received and stored for " + email);
             return Response.ok("OAuth2 token successfully received and stored.").build();
         } catch (Exception e) {
-            LOG.severe("Error during OAuth callback for " + email + ": " + e.getMessage());
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Error processing callback: " + escapeForHtml(e.getMessage())).build();
+            LOG.log(java.util.logging.Level.SEVERE, "Error during OAuth callback for " + email, e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Error processing callback.").build();
         }
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ChrAu/feed2mastodon/security/code-scanning/78](https://github.com/ChrAu/feed2mastodon/security/code-scanning/78)

To fix this, ensure user-controlled values are contextually encoded before placing them into response bodies. Here, the minimal non-breaking fix is to HTML-escape `error`, `errorDescription`, `email`, and exception messages wherever they are reflected in `Response.entity(...)`.

Best implementation in this file:
- Add a small helper `escapeForHtml(String)` in `MailOAuthResource` (near existing `sanitizeForLog`).
- Use it when building all response entity strings that include user-influenced content:
  - OAuth error response (line ~78),
  - Not found/provider error messages including email (lines ~89, ~97),
  - Success message with email (line ~104),
  - Exception message in callback error response (line ~107).

This addresses both alert variants (`error` and `error_description`) with one consistent fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
