### PR TITLE
Potential fix for code scanning alert no. 105: Cross-site scripting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.hexix</groupId>
     <artifactId>feed2mastodon</artifactId>
-    <version>0.8.33</version>
+    <version>0.8.34</version>
 
     <properties>
         <compiler-plugin.version>3.15.0</compiler-plugin.version>

--- a/src/main/java/de/hexix/mail/MailOAuthResource.java
+++ b/src/main/java/de/hexix/mail/MailOAuthResource.java
@@ -92,7 +92,7 @@ public class MailOAuthResource {
         if (error != null) {
             LOG.warning("OAuth callback received an error: " + safeError + " - " + safeErrorDescription);
             return Response.status(Response.Status.BAD_REQUEST)
-                    .entity("OAuth error: " + escapeForHtml(error) + (errorDescription != null ? " (" + escapeForHtml(errorDescription) + ")" : "")).build();
+                    .entity("OAuth error returned by provider.").build();
         }
 
         if (code == null || email == null) {


### PR DESCRIPTION
Potential fix for [https://github.com/ChrAu/feed2mastodon/security/code-scanning/105](https://github.com/ChrAu/feed2mastodon/security/code-scanning/105)

General fix: do not include raw or transformed user input in HTTP error response bodies for OAuth callback parameters. Return a generic error message to clients and keep detailed values only in server logs (already sanitized for logs).

Best fix in this file: in `src/main/java/de/hexix/mail/MailOAuthResource.java`, within `callback(...)`, replace the BAD_REQUEST entity construction that concatenates `escapeForHtml(error)` and `escapeForHtml(errorDescription)` with a constant, non-reflective message. This preserves functionality (client still gets 400 and an OAuth error message) while eliminating reflected XSS risk and addressing both `error` and `error_description` variants. No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
