### PR TITLE
Potential fix for code scanning alert no. 97: URL redirection from remote source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.hexix</groupId>
     <artifactId>feed2mastodon</artifactId>
-    <version>0.8.33</version>
+    <version>0.8.34</version>
 
     <properties>
         <compiler-plugin.version>3.15.0</compiler-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.hexix</groupId>
     <artifactId>feed2mastodon</artifactId>
-    <version>0.8.34</version>
+    <version>0.8.35</version>
 
     <properties>
         <compiler-plugin.version>3.15.0</compiler-plugin.version>

--- a/src/main/java/de/hexix/user/UserResource.java
+++ b/src/main/java/de/hexix/user/UserResource.java
@@ -15,11 +15,19 @@ import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import java.net.URI;
 import java.security.Principal;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 @Path("/api/user")
 public class UserResource {
+
+    private static final Set<String> ALLOWED_REDIRECT_PATHS = Collections.unmodifiableSet(Set.of(
+            "/",
+            "/profile",
+            "/dashboard"
+    ));
 
     @Inject
     SecurityIdentity securityIdentity;
@@ -58,8 +66,8 @@ public class UserResource {
     @Path("/login")
     @Authenticated // Das hier triggert den Redirect zu Keycloak
     public Response login(@QueryParam("redirect") String redirect) {
-        // Validierung: Nur interne Pfade erlauben (Open Redirect Protection!)
-        String target = (redirect != null && redirect.startsWith("/")) ? redirect : "/";
+        // Validierung: Nur explizit freigegebene interne Pfade erlauben (Open Redirect Protection!)
+        String target = (redirect != null && ALLOWED_REDIRECT_PATHS.contains(redirect)) ? redirect : "/";
         return Response.seeOther(URI.create(target)).build();
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ChrAu/feed2mastodon/security/code-scanning/97](https://github.com/ChrAu/feed2mastodon/security/code-scanning/97)

Use a **server-side allowlist of redirect paths** and only redirect when the provided value exactly matches one of those allowed paths. Otherwise, fall back to `/`.

Best fix in this file:
- In `src/main/java/de/hexix/user/UserResource.java`, add imports for `java.util.Set` and `java.util.Collections`.
- Define a private static final allowlist, e.g. `ALLOWED_REDIRECT_PATHS`.
- In `login(...)`, replace the `startsWith("/")` validation with an allowlist membership check.
- Keep behavior unchanged for invalid/missing redirect by defaulting to `/`.

This preserves functionality (user can still request specific post-login routes) while preventing arbitrary user-controlled redirect targets.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
